### PR TITLE
updated for installation on OSX 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Includes:
  Constraints $ forall onus $ \j -> (sum splitters $ \i -> 1 :# (Phi i j) ) := 1
 ```
 
+## Installing on OSX
+To install on OSX with cplex in the standard install location, specify the extra-lib-dirs as: `cabal install cplex-hs --extra-lib-dirs=$HOME/Applications/IBM/ILOG/CPLEX_Studio1271/cplex/lib/x86-64_osx/static_pic/`
+
 ## Change Log
 * New MIP additions and callbacks
 * MIP additions by [herwigstuetz](https://github.com/herwigstuetz/cplex-haskell)

--- a/cplex-hs.cabal
+++ b/cplex-hs.cabal
@@ -14,6 +14,9 @@ Stability:           Experimental
 Description:
     High level interface to CPLEX
 
+    To install on OSX with cplex in the standard install location, specify the extra-lib-dirs as: @cabal install cplex-hs --extra-lib-dirs=$HOME/Applications/IBM/ILOG/CPLEX_Studio1271/cplex/lib/x86-64_osx/static_pic/@
+
+
 build-type:          Simple
 cabal-version:       >=1.24
 Library
@@ -32,7 +35,7 @@ Library
                    , mtl < 2.3
                    , primitive < 0.7.0.0
                    , transformers < 0.5.3.0
-                   , vector < 0.12.0.0
+                   , vector < 0.13.0.0
   hs-source-dirs:    src
 
   if os(linux)
@@ -40,4 +43,5 @@ Library
       Extra-libraries: cplex, m, pthread
       Include-dirs:    /opt/ibm/ILOG/CPLEX_Studio_Community1263/cplex/include/
       cc-options: -Wall -Wextra
-
+  if os(OSX)
+      Extra-libraries: cplex, m, pthread


### PR DESCRIPTION
updated the cabal file with the new vector library version and the extra-libraries and extra-lib-dirs for OSX; updated the README with notes about installation on OSX